### PR TITLE
UI: Fix audio recording for lossless simple

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -242,6 +242,8 @@ void SimpleOutput::LoadRecordingPreset_Lossless()
 	obs_data_set_string(settings, "video_encoder", "utvideo");
 	obs_data_set_string(settings, "audio_encoder", "pcm_s16le");
 
+	int aMixes = 1;
+	obs_output_set_mixers(fileOutput, aMixes);
 	obs_output_update(fileOutput, settings);
 	obs_data_release(settings);
 }


### PR DESCRIPTION
The first audio track was not recorded following the API changes for
 custom ffmpeg recording (adding multi-track support).
 This fixes the issue (spotted by EposVox, thanks to him for the report).