### PR TITLE
UI: Align Settings labels to left (& Properties labels)

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -833,6 +833,12 @@ QLabel#errorLabel {
 	font-weight: bold;
 }
 
+/* Obs source label */
+
+OBSSourceLabel {
+	font-weight: bold;
+}
+
 /* Settings Menu */
 
 #buttonBox {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -137,8 +137,9 @@ QGroupBox {
     border: 1px solid rgb(31,30,31); /* veryDark */;
     border-radius: 5px;
     padding-top: 16px;
+    font-weight: bold;
+    margin-top: 20px;
 }
-
 
 /* ScrollBars */
 
@@ -635,7 +636,6 @@ SourceTreeSubItemCheckBox::indicator:unchecked {
     image: url(./Dark/collapse.png);
 }
 
-
 /* Label warning/error */
 
 QLabel#warningLabel {
@@ -645,6 +645,12 @@ QLabel#warningLabel {
 
 QLabel#errorLabel {
     color: rgb(192, 0, 0);
+    font-weight: bold;
+}
+
+/* Obs source label */
+
+OBSSourceLabel {
     font-weight: bold;
 }
 

--- a/UI/data/themes/Default.qss
+++ b/UI/data/themes/Default.qss
@@ -101,6 +101,12 @@ QLabel#errorLabel {
     font-weight: bold;
 }
 
+/* Obs source label */
+
+OBSSourceLabel {
+    font-weight: bold;
+}
+
 * [themeID="warning"] {
     color: rgb(192, 128, 0);
     font-weight: bold;
@@ -140,4 +146,9 @@ QLabel#errorLabel {
 
 * [themeID="displayBackgroundColor"] {
     qproperty-displayBackgroundColor: rgb(76, 76, 76);
+}
+
+/* groupbox titles */
+QGroupBox {
+    font-weight: bold;
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -217,6 +217,7 @@ QGroupBox {
 	border-radius: 2px;
 	padding-top: 16px;
 	margin-top: 20px;
+	font-weight: bold;
 }
 
 QGroupBox::title {
@@ -1040,6 +1041,12 @@ QLabel#warningLabel {
 
 QLabel#errorLabel {
 	color: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
+	font-weight: bold;
+}
+
+/* Obs source label */
+
+OBSSourceLabel {
 	font-weight: bold;
 }
 

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -175,7 +175,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -343,7 +343,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -550,7 +550,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -595,7 +595,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -745,7 +745,7 @@
                      <string>Basic.Settings.Stream.StreamType</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <property name="buddy">
                      <cstring>streamType</cstring>
@@ -838,7 +838,7 @@
                    <string>Basic.Settings.Output.Mode</string>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                   </property>
                   <property name="buddy">
                    <cstring>outputMode</cstring>
@@ -916,7 +916,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_19">
@@ -930,7 +930,7 @@
                        <string>Basic.Settings.Output.VideoBitrate</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                       </property>
                       <property name="buddy">
                        <cstring>simpleOutputVBitrate</cstring>
@@ -1100,7 +1100,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_18">
@@ -1114,7 +1114,7 @@
                        <string>Basic.Settings.Output.Simple.SavePath</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                       </property>
                       <property name="buddy">
                        <cstring>simpleOutputPath</cstring>
@@ -1258,7 +1258,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_35">
@@ -1442,7 +1442,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="1" column="0">
                             <widget class="QLabel" name="label_28">
@@ -1456,7 +1456,7 @@
                               <string>Basic.Settings.Output.Adv.AudioTrack</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                             </widget>
                            </item>
@@ -1553,20 +1553,43 @@
                             </widget>
                            </item>
                            <item row="4" column="0">
-                            <widget class="QCheckBox" name="advOutUseRescale">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
+                            <layout class="QHBoxLayout" name="horizontalLayout_123">
+                             <property name="spacing">
+                              <number>3</number>
                              </property>
-                             <property name="layoutDirection">
-                              <enum>Qt::RightToLeft</enum>
+                             <property name="leftMargin">
+                              <number>0</number>
                              </property>
-                             <property name="text">
-                              <string>Basic.Settings.Output.Adv.Rescale</string>
+                             <property name="topMargin">
+                              <number>0</number>
                              </property>
+                             <property name="rightMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="bottomMargin">
+                              <number>0</number>
+                             </property>
+                             <item>
+                              <widget class="QLabel" name="label_rescale_str">
+                               <property name="text">
+                                <string>Basic.Settings.Output.Adv.Rescale</string>
+                               </property>
+                               <property name="buddy">
+                                <cstring>advOutUseRescale</cstring>
+                               </property>
+                              </widget>
+                             </item>
+                             <item>
+                              <widget class="QCheckBox" name="advOutUseRescale">
+                               <property name="sizePolicy">
+                                <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                 <horstretch>0</horstretch>
+                                 <verstretch>0</verstretch>
+                                </sizepolicy>
+                               </property>
                             </widget>
+                             </item>
+                             </layout>
                            </item>
                            <item row="4" column="1">
                             <widget class="QComboBox" name="advOutRescale">
@@ -1610,7 +1633,7 @@
                          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                         </property>
                         <property name="labelAlignment">
-                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                         <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                         </property>
                         <property name="topMargin">
                          <number>0</number>
@@ -1630,7 +1653,7 @@
                            <string>Basic.Settings.Output.Adv.Recording.Type</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                           </property>
                           <property name="buddy">
                            <cstring>advOutRecType</cstring>
@@ -1693,7 +1716,7 @@
                              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                             </property>
                             <property name="labelAlignment">
-                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                             </property>
                             <property name="topMargin">
                              <number>0</number>
@@ -1716,7 +1739,7 @@
                                <string>Basic.Settings.Output.Simple.SavePath</string>
                               </property>
                               <property name="alignment">
-                               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                               <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                               </property>
                               <property name="buddy">
                                <cstring>advOutRecPath</cstring>
@@ -1885,20 +1908,43 @@
                              <widget class="QComboBox" name="advOutRecEncoder"/>
                             </item>
                             <item row="5" column="0">
-                             <widget class="QCheckBox" name="advOutRecUseRescale">
-                              <property name="sizePolicy">
-                               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                                <horstretch>0</horstretch>
-                                <verstretch>0</verstretch>
-                               </sizepolicy>
+                             <layout class="QHBoxLayout" name="horizontalLayout_122">
+                              <property name="spacing">
+                               <number>3</number>
                               </property>
-                              <property name="layoutDirection">
-                               <enum>Qt::RightToLeft</enum>
+                              <property name="leftMargin">
+                               <number>0</number>
                               </property>
-                              <property name="text">
-                               <string>Basic.Settings.Output.Adv.Rescale</string>
+                              <property name="topMargin">
+                               <number>0</number>
                               </property>
-                             </widget>
+                              <property name="rightMargin">
+                               <number>0</number>
+                              </property>
+                              <property name="bottomMargin">
+                               <number>0</number>
+                              </property>
+                              <item>
+                               <widget class="QLabel" name="label_rescale_std">
+                                <property name="text">
+                                 <string>Basic.Settings.Output.Adv.Rescale</string>
+                                </property>
+                                <property name="buddy">
+                                 <cstring>advOutRecUseRescale</cstring>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QCheckBox" name="advOutRecUseRescale">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                               </widget>
+			      </item>
+			     </layout>
                             </item>
                             <item row="5" column="1">
                              <widget class="QWidget" name="advOutRecRescaleContainer" native="true">
@@ -1970,7 +2016,7 @@
                           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                          </property>
                          <property name="labelAlignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                          </property>
                          <property name="topMargin">
                           <number>0</number>
@@ -1993,7 +2039,7 @@
                             <string>Basic.Settings.Output.Adv.FFmpeg.SavePathURL</string>
                            </property>
                            <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                           </widget>
                          </item>
@@ -2134,20 +2180,43 @@
                           </widget>
                          </item>
                          <item row="9" column="0">
-                          <widget class="QCheckBox" name="advOutFFUseRescale">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
+                          <layout class="QHBoxLayout" name="horizontalLayout_121">
+                           <property name="spacing">
+                            <number>3</number>
                            </property>
-                           <property name="layoutDirection">
-                            <enum>Qt::RightToLeft</enum>
+                           <property name="leftMargin">
+                            <number>0</number>
                            </property>
-                           <property name="text">
-                            <string>Basic.Settings.Output.Adv.Rescale</string>
+                           <property name="topMargin">
+                            <number>0</number>
                            </property>
-                          </widget>
+                           <property name="rightMargin">
+                            <number>0</number>
+                           </property>
+                           <property name="bottomMargin">
+                            <number>0</number>
+                           </property>
+                           <item>
+                            <widget class="QLabel" name="label_rescale">
+                             <property name="text">
+                              <string>Basic.Settings.Output.Adv.Rescale</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutFFUseRescale</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QCheckBox" name="advOutFFUseRescale">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
                          </item>
                          <item row="9" column="1">
                           <widget class="QComboBox" name="advOutFFRescale">
@@ -2338,7 +2407,7 @@
                             <string>Basic.Settings.Output.Adv.FFmpeg.Type</string>
                            </property>
                            <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <property name="buddy">
                             <cstring>advOutFFType</cstring>
@@ -2430,7 +2499,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="1">
                             <widget class="QComboBox" name="advOutTrack1Bitrate">
@@ -2506,7 +2575,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack1Bitrate</cstring>
@@ -2545,7 +2614,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_49">
@@ -2559,7 +2628,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack2Bitrate</cstring>
@@ -2660,7 +2729,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_51">
@@ -2674,7 +2743,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack3Bitrate</cstring>
@@ -2775,7 +2844,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_53">
@@ -2789,7 +2858,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack4Bitrate</cstring>
@@ -2890,7 +2959,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_59">
@@ -2904,7 +2973,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack5Bitrate</cstring>
@@ -3005,7 +3074,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_61">
@@ -3019,7 +3088,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack6Bitrate</cstring>
@@ -3242,7 +3311,7 @@
           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
          </property>
          <property name="labelAlignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
          </property>
          <item row="0" column="0">
           <widget class="QLabel" name="label_14">
@@ -3341,7 +3410,7 @@
             <string>Basic.Settings.Audio.DesktopDevice</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>desktopAudioDevice1</cstring>
@@ -3361,7 +3430,7 @@
             <string>Basic.Settings.Audio.DesktopDevice2</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>desktopAudioDevice2</cstring>
@@ -3569,7 +3638,7 @@
           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
          </property>
          <property name="labelAlignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
          </property>
          <item row="0" column="0">
           <widget class="QLabel" name="label_8">
@@ -3583,7 +3652,7 @@
             <string>Basic.Settings.Video.BaseResolution</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>baseResolution</cstring>
@@ -3780,7 +3849,7 @@
               <enum>QFormLayout::ExpandingFieldsGrow</enum>
              </property>
              <property name="labelAlignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
              </property>
              <property name="leftMargin">
               <number>0</number>
@@ -3874,7 +3943,7 @@
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
           <property name="labelAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
           </property>
           <property name="verticalSpacing">
            <number>0</number>
@@ -3942,7 +4011,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -3986,7 +4055,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4014,7 +4083,7 @@
                       <string>Basic.Settings.Video.Adapter</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>adapter</cstring>
@@ -4043,7 +4112,7 @@
                       <string>Basic.Settings.Advanced.Video.ColorFormat</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>colorFormat</cstring>
@@ -4189,7 +4258,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4240,7 +4309,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4353,7 +4422,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4470,7 +4539,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4570,7 +4639,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -122,7 +122,7 @@ void OBSPropertiesView::RefreshProperties()
 	QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 	//widget->setSizePolicy(policy);
 
-	layout->setLabelAlignment(Qt::AlignRight);
+	layout->setLabelAlignment(Qt::AlignLeft);
 
 	obs_property_t *property = obs_properties_first(properties.get());
 	bool hasNoProperties = !property;
@@ -1392,7 +1392,7 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 
 	if (label && minSize) {
 		label->setMinimumWidth(minSize);
-		label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+		label->setAlignment(Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter);
 	}
 
 	if (label && !obs_property_enabled(property))

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1161,6 +1161,8 @@ void OBSBasicSettings::LoadStream1Settings()
 			170);
 
 	streamProperties->setProperty("changed", QVariant(false));
+	streamProperties->setProperty("labelAlignment",
+			QVariant(Qt::AlignLeft | Qt::AlignLeading | Qt::AlignVCenter));
 	layout->addWidget(streamProperties);
 
 	QObject::connect(streamProperties, SIGNAL(Changed()),
@@ -2421,7 +2423,7 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 	layout->setVerticalSpacing(0);
 	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	layout->setLabelAlignment(
-			Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter);
+			Qt::AlignLeft |Qt::AlignLeading|Qt::AlignVCenter);
 
 	auto widget = new QWidget();
 	widget->setLayout(layout);
@@ -2436,7 +2438,6 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 
 	auto setRowVisible = [=](int row, bool visible, QLayoutItem *label) {
 		label->widget()->setVisible(visible);
-
 		auto field = layout->itemAt(row, QFormLayout::FieldRole);
 		if (field)
 			field->widget()->setVisible(visible);


### PR DESCRIPTION
Following a request by our chief-designer Warchamp, this patch aligns
Settings labels to the left.
Headers have been boldened to distinguish them from the sublabels.
This has required to align also labels in Properties (ex: source
property window).